### PR TITLE
Handle user cancel as error #1

### DIFF
--- a/lib/request_code.dart
+++ b/lib/request_code.dart
@@ -32,8 +32,8 @@ class RequestCode {
 
           if (uri.queryParameters["error"] != null) {
             Navigator.of(_config.context!).pop();
-            _onCodeListener.addError(
-                new Exception("Access denied or authentation canceled."));
+            _onCodeListener
+                .addError(Exception("Access denied or authentation canceled."));
           }
 
           if (uri.queryParameters["code"] != null) {

--- a/lib/request_code.dart
+++ b/lib/request_code.dart
@@ -32,7 +32,8 @@ class RequestCode {
 
           if (uri.queryParameters["error"] != null) {
             Navigator.of(_config.context!).pop();
-            throw new Exception("Access denied or authentation canceled.");
+            _onCodeListener.addError(
+                new Exception("Access denied or authentation canceled."));
           }
 
           if (uri.queryParameters["code"] != null) {


### PR DESCRIPTION
The previous exception was not being captured and forwarded along to the consumer. By adding it instead as an error to the onCodeListener, is gets thrown on the `code = await _onCode.first;`.

