### PR TITLE
fix: android storage

### DIFF
--- a/lib/data/implementations/mobile_storage.dart
+++ b/lib/data/implementations/mobile_storage.dart
@@ -3,7 +3,12 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import '../i_storage.dart';
 
 class MobileStorage extends IStorage {
-  final FlutterSecureStorage _secureStorage = const FlutterSecureStorage();
+  final FlutterSecureStorage _secureStorage = const FlutterSecureStorage(
+    aOptions: AndroidOptions(
+      encryptedSharedPreferences: true,
+    ),
+  );
+
   @override
   Future<void> delete({required String key}) async {
     await _secureStorage.delete(key: key);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_aad_oauth
 description: A Flutter OAuth package for performing user authentication against Azure Active Directory OAuth2 v2.0 endpoint.
-version: 2.3.0
+version: 2.4.0
 homepage: https://github.com/p-stannis/flutter_aad_oauth
 
 environment:


### PR DESCRIPTION
This library stopped working for some android devices (a lot of Samsung ones).
The error are generated when calling login function, here's an example
<img width="450" alt="image" src="https://user-images.githubusercontent.com/18094686/203598461-ce2b2cd6-6866-4636-a7b4-6991652d982d.png">

The problem are in `flutter_secure_storage` library, and need just one little change to be fixed, as reported [here](https://github.com/mogol/flutter_secure_storage/issues/354#issuecomment-1170367152)

I tested the changes and It fixes the issue


